### PR TITLE
Change authentication scopes to work with new API, fix token expiry

### DIFF
--- a/lib/pluot/client.rb
+++ b/lib/pluot/client.rb
@@ -10,7 +10,6 @@ module Pluot
     API_ENDPOINT  = 'https://api.wildapricot.org'
     API_NAMESPACE = '/v2'
 
-
     attr_reader :api_key, :account_id, :config
 
     def initialize(api_key, account_id, config = {})

--- a/lib/pluot/client.rb
+++ b/lib/pluot/client.rb
@@ -46,7 +46,12 @@ module Pluot
     end
 
     def auth_token
-      @token ||= Oauth.new(api_key, config).token
+      if @token.nil? or Time.now > (@tokentime + 6000)
+        @tokentime = Time.now
+        @token = Oauth.new(api_key, config).token
+      else
+        @token
+      end
     end
 
   end

--- a/lib/pluot/client.rb
+++ b/lib/pluot/client.rb
@@ -46,7 +46,9 @@ module Pluot
     end
 
     def auth_token
-      if @token.nil? or Time.now > (@tokentime + 6000)
+      # wild apricot typically gives us an 1800 second token, let's only keep
+      # ours for ten minutes
+      if @token.nil? or Time.now > (@tokentime + 600)
         @tokentime = Time.now
         @token = Oauth.new(api_key, config).token
       else

--- a/lib/pluot/oauth.rb
+++ b/lib/pluot/oauth.rb
@@ -5,12 +5,18 @@ require 'base64'
 module Pluot
   class Oauth
 
+    class InvalidAuthorization < StandardError
+    end
+    
     ENDPOINT   = 'https://oauth.wildapricot.org/auth/token'
+
+    # by default we will fetch read-only credentials. for RW,
+    # the client must update their config[:auth_type]
     AUTH_SCOPE = [
-      :contacts,
-      :finances,
-      :events,
-      :account
+      :contacts_view,
+      :finances_view,
+      :events_view,
+      :account_view
     ].join(' ')
 
     attr_reader :api_key, :auth_scope
@@ -21,7 +27,14 @@ module Pluot
     end
 
     def token
-      connection.post(ENDPOINT, params).body[:access_token]
+      res = connection.post(ENDPOINT, params)
+      token = res.body[:access_token]
+
+      if token.blank?
+        raise InvalidAuthorization
+      end
+
+      token
     end
 
     private


### PR DESCRIPTION
There are a couple of problems in the current version of the client that need correcting if the gem is to be used in a production environment. This pull request addresses both issues.

1) The auth scopes have changed, so I've updated them.

2) If the gem is used in a long-running process (greater than ten minutes), the OAuth token will expire and the gem will stop working. This change also addresses OAuth token expiry and renews the token as needed. 

3) It is possible for authentication to silently fail with no notification to the caller. I've modified this to raise an exception if the auth fails.

Also, my apologies in advance for not putting this into two separate feature branches, I had these issues in a running system and had to quickly patch. Upon your request I can move them to branches.

Thanks for writing this.
